### PR TITLE
Add configuration options for request module to gruntfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ Type: `String` <br/>
 Default value: `w3c_validation_error_Template.html`
 Expects name for 'Handlebar' template to generate the error's HTMLs. Sample template is provided with plug-in in root folder.
 
+#### options.request
+Type `object` <br/>
+Default value: `undefined`
+
+Configuration for the `request` Module. For more information please read [the docs](https://github.com/request/request/tree/v2.40.0).
+
 ## Regular grunt-html-validation Options
 
 #### options.reset
@@ -306,9 +312,9 @@ Report issues [here](https://github.com/vikash-bhardwaj/grunt-w3c-html-validatio
  * 2015-03-19   v0.0.1   Updated Package.json and License file to publish the plug-in with new features.
  * 2014-05-27   v0.1.18  Version bump, Fixes #54
  * 2014-05-15   v0.1.17  Fixes #50, #52
- * 2014-04-23   v0.1.16  Fixes  
- * 2014-04-03   v0.1.15  Updated dependencies (jshnt, nodeunit, request), gitignore, code cleanup etc.. 
- * 2014-03-23   v0.1.14  Updated with wrapfile & server url options.  
+ * 2014-04-23   v0.1.16  Fixes
+ * 2014-04-03   v0.1.15  Updated dependencies (jshnt, nodeunit, request), gitignore, code cleanup etc..
+ * 2014-03-23   v0.1.14  Updated with wrapfile & server url options.
  * 2013-12-26   v0.1.13  Fixed running multiple tasks fail due to validation failure.
  * 2013-12-17   v0.1.11  Option to set proxy, w3cjs updated to 0.1.22, added fail hard and some bug fixes
  * 2013-11-22   v0.1.9   Fix some bugs

--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -72,13 +72,13 @@ module.exports = function (grunt) {
             useTimeStamp: false,
             errorTemplate: "error_Template.html"
         });
-        
+
         var done = this.async(),
             files = grunt.file.expand(this.filesSrc),
             flen = files.length,
             readSettings = {},
             isRelaxError = false;
-        
+
         isRelaxError = options.relaxerror.length && options.relaxerror.length !== '';
 
         var makeFileList = function (files) {
@@ -311,7 +311,7 @@ module.exports = function (grunt) {
                                 return;
                             }
 
-                            rval(dummyFile[counter], function () {
+                            rval(dummyFile[counter], options.request, function () {
                                 validate(files);
                             });
 
@@ -377,7 +377,7 @@ module.exports = function (grunt) {
         if (options.remotePath && options.remotePath !== '') {
             files = makeFileList(files);
         }
-        
+
         if (options.remoteFiles) {
 
             if (typeof options.remoteFiles === 'object' && options.remoteFiles.length && options.remoteFiles[0] !== '') {
@@ -406,11 +406,11 @@ module.exports = function (grunt) {
                  */
                 var filePathTemp = dummyFile[i].split("/");
                 filePathTemp = (filePathTemp[filePathTemp.length-1].indexOf(".") === -1) ? filePathTemp.slice(filePathTemp.length-2).join("") : filePathTemp.slice(filePathTemp.length-2).join("").split(".")[0];
-                
+
                 files.push(filePathTemp + '_tempvlidation.html');
             }
 
-            rval(dummyFile[counter], function () {
+            rval(dummyFile[counter], options.request, function () {
                 validate(files);
             });
 

--- a/tasks/lib/remoteval.js
+++ b/tasks/lib/remoteval.js
@@ -10,12 +10,15 @@
 
 'use strict';
 
-module.exports = function remoteval (file, cb) {
+module.exports = function remoteval (file, opts, cb) {
 
     var request = require('request');
     var grunt = require('grunt');
 
-    request(file, function (error, response, body) {
+    opts = opts || {};
+    opts.uri = file;
+
+    request(opts, function (error, response, body) {
         if (response.statusCode === 404) {
             console.log(fileNotFound);
         }


### PR DESCRIPTION
There are so many configuration options in the request module you are using. These should be accesible from the Gruntfile to better integrate the validator into your environment, e.g. when using a server with HTTP authentication or SSL without a certificate.
