### PR TITLE
Fixed temp file path construction bug

### DIFF
--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -457,7 +457,7 @@ module.exports = function (grunt) {
                  */
                 var filePathTemp = dummyFile[i].split("/");
                 
-                filePathTemp = (filePathTemp[filePathTemp.length-1].indexOf(".") === -1) ? filePathTemp.slice(filePathTemp.length-2).split("?")[0].join("") : filePathTemp.slice(filePathTemp.length-2).join("").split(".")[0];
+                filePathTemp = (filePathTemp[filePathTemp.length-1].indexOf(".") === -1) ? filePathTemp.slice(filePathTemp.length-2)[0].split("?")[0] : filePathTemp.slice(filePathTemp.length-2).join("").split(".")[0];
 
                 filePathTemp.replace(/[&./http(s):=?]/g, "");
 

--- a/tasks/lib/generateHTMLReport.js
+++ b/tasks/lib/generateHTMLReport.js
@@ -43,7 +43,7 @@ module.exports = function generateHTMLReport(errorFileObj, options, errorFileCou
     if (!options.errorFileFunction) {
         var filePathTemp = curruntErrorFile["filename"].split("/");
 
-        filePathTemp = (filePathTemp[filePathTemp.length-1].indexOf(".") === -1) ? filePathTemp.slice(filePathTemp.length-2).split("?")[0].join("") : filePathTemp.slice(filePathTemp.length-2).join("").split(".")[0];
+        filePathTemp = (filePathTemp[filePathTemp.length-1].indexOf(".") === -1) ? filePathTemp.slice(filePathTemp.length-2)[0].split("?")[0] : filePathTemp.slice(filePathTemp.length-2).join("").split(".")[0];
 
         filePathTemp.replace(/\,\<\>\?\|\*\:\"/, '');
 


### PR DESCRIPTION
Obviously there was something wrong about the construction of temporary file paths (trying to `.split()` an array ...).
