### PR TITLE
[~HOTFIX] rename errorFileName to valid option errorFileFunction

### DIFF
--- a/tasks/lib/generateHTMLReport.js
+++ b/tasks/lib/generateHTMLReport.js
@@ -49,7 +49,7 @@ module.exports = function generateHTMLReport(errorFileObj, options, errorFileCou
 
         filePath = filePathTemp + "_validation-report" + ".html";
     } else if (typeof options.errorFileFunction === 'function') {
-        filePath = options.errorFileName( curruntErrorFile['filename'] );
+        filePath = options.errorFileFunction( curruntErrorFile['filename'] );
     }
 
     var errorCompletePath = (/([^\s])/.test(options.errorHTMLRootDir) === false) ? folderPath + "/" + filePath : options.errorHTMLRootDir + "/" + folderPath + "/" + filePath;


### PR DESCRIPTION
Option errorFileFunction is not working. Fixed by renaming errorFileName to errorFileFunction
