### PR TITLE
Get it compatible to grunt-critical

### DIFF
--- a/tasks/html_validation.js
+++ b/tasks/html_validation.js
@@ -28,8 +28,7 @@ module.exports = function (grunt) {
         help: 'cyan',
         warn: 'yellow',
         debug: 'blue',
-        error: 'red',
-        blue: 'blue'
+        error: 'red'
     });
 
     var counter = 0,


### PR DESCRIPTION
Removed invalid color.js configuration. Otherwise grunt-critical crashes after loading the task with: 
```grunt.loadNpmTasks('grunt-w3c-html-validation');```